### PR TITLE
Add support for all VS2017 editions, not just the Build Tools

### DIFF
--- a/WebKitDev/Functions/Get-VSBuildTools2017InstallationPath.ps1
+++ b/WebKitDev/Functions/Get-VSBuildTools2017InstallationPath.ps1
@@ -21,6 +21,26 @@ Function Get-VSBuildTools2017InstallationPath {
     }
   }
 
+  # If the Build Tools are not found, try Enterprise, then Professional, and then Community.
+  # These packages all contain the Build Tools as a component.
+  foreach ($install in $installs) {
+    if ($install.DisplayName -eq 'Visual Studio Enterprise 2017') {
+      return $install.InstallationPath;
+    }
+  }
+
+  foreach ($install in $installs) {
+    if ($install.DisplayName -eq 'Visual Studio Professional 2017') {
+      return $install.InstallationPath;
+    }
+  }
+
+  foreach ($install in $installs) {
+    if ($install.DisplayName -eq 'Visual Studio Community 2017') {
+      return $install.InstallationPath;
+    }
+  }
+
   # Return the default path
   return 'C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools';
 }


### PR DESCRIPTION
All of the full VS2017 editions include the Build Tools as a component. However, the Build Tools will still be used first, if found.

I added this because I have VS2017 Community installed on my workstation. I do not want to, and do not need to, install the Build Tools alongside that. (In fact, one might argue that I actually cannot, as once one edition of VS2017 is installed, the VS2017 Installer hides all lower editions; e.g. installing Professional hides Community.)