### PR TITLE
Invoke-CMakeBuild now throws an error if the CMake build failed

### DIFF
--- a/WebKitDev/Functions/Invoke-CMakeBuild.ps1
+++ b/WebKitDev/Functions/Invoke-CMakeBuild.ps1
@@ -89,4 +89,9 @@ Function Invoke-CMakeBuild {
 
   Write-Host $buildCall;
   Invoke-Expression $buildCall;
+  $cmakeExitCode = $LASTEXITCODE;
+
+  if ($cmakeExitCode -ne 0) {
+    throw "CMake failed with code {0}" -f $cmakeExitCode
+  }
 }


### PR DESCRIPTION
Previously, it would silently continue in such a case. While working on the WinCairoDependencies build, this causes great annoyance because one failed component will not stop the build cycle entirely, making any error messages harder to track down.