### PR TITLE
fix(): Add proxy support

### DIFF
--- a/WebKitDev/Functions/Invoke-WebFileRequest.ps1
+++ b/WebKitDev/Functions/Invoke-WebFileRequest.ps1
@@ -98,7 +98,7 @@ Function Invoke-WebFileRequest {
     $tcpClient.Proxy = $proxy;
     $tcpClient.DownloadFile($url, $destinationPath);
 
-    if ($secure -and $oldSecurityProtocol) {
+    if ($oldSecurityProtocol) {
         # Restore the security protocol
         [System.Net.ServicePointManager]::SecurityProtocol = $oldSecurityProtocol;
     }

--- a/WebKitDev/Functions/Invoke-WebFileRequest.ps1
+++ b/WebKitDev/Functions/Invoke-WebFileRequest.ps1
@@ -25,7 +25,7 @@ Function Invoke-WebFileRequest {
 
     # See if security protocol needs to be checked
     $secure = 1;
-    if ($url.StartsWith("http://")) {
+    if ($url.StartsWith('http:')) {
         $secure = 0;
     }
 
@@ -37,6 +37,11 @@ Function Invoke-WebFileRequest {
         if ($secure) {
             if (Test-Path env:HTTPS_PROXY) {
                 $proxy = New-Object System.Net.WebProxy($env:HTTPS_PROXY, $true);
+
+                # Turn off SSL protocol check if proxy is HTTP
+                if ($env:HTTPS_PROXY.StartsWith('http:')) {
+                    $secure = 0;
+                }
             }
         } else {
             if (Test-Path env:HTTP_PROXY) {
@@ -53,14 +58,14 @@ Function Invoke-WebFileRequest {
         $securityProtocol = 0;
         $testEndpoint = [System.Uri]$url;
 
-        if ($proxy.Address -eq $null) {
+        if ($proxy.Address -ne $null) {
             $testEndpoint = $proxy.Address;
         }
 
         foreach ($protocol in 'tls12', 'tls11', 'tls') {
             $tcpClient = New-Object Net.Sockets.TcpClient;
             $tcpClient.Connect($testEndpoint.Host, $testEndpoint.Port)
-    
+
             $sslStream = New-Object Net.Security.SslStream $tcpClient.GetStream();
             $sslStream.ReadTimeout = 15000;
             $sslStream.WriteTimeout = 15000;

--- a/WebKitDev/Functions/Invoke-WebFileRequest.ps1
+++ b/WebKitDev/Functions/Invoke-WebFileRequest.ps1
@@ -23,9 +23,26 @@ Function Invoke-WebFileRequest {
         [string] $destinationPath
     )
 
+    # See if security protocol needs to be checked
     $secure = 1;
     if ($url.StartsWith("http://")) {
         $secure = 0;
+    }
+
+    # Setup a proxy if needed
+    $proxy = [System.Net.WebProxy]::GetDefaultProxy();
+    $proxyServer = $proxy.Address;
+
+    if ($proxy.Address -eq $null) {
+        if ($secure) {
+            if (Test-Path env:HTTPS_PROXY) {
+                $proxy = New-Object System.Net.WebProxy($env:HTTPS_PROXY, $true);
+            }
+        } else {
+            if (Test-Path env:HTTP_PROXY) {
+                $proxy = New-Object System.Net.WebProxy($env:HTTP_PROXY, $true);
+            }
+        }
     }
 
     if ($secure) {
@@ -34,18 +51,22 @@ Function Invoke-WebFileRequest {
 
         # Determine the security protocol required
         $securityProtocol = 0;
-        $uri = [System.Uri]$url;
+        $testEndpoint = [System.Uri]$url;
+
+        if ($proxy.Address -eq $null) {
+            $testEndpoint = $proxy.Address;
+        }
 
         foreach ($protocol in 'tls12', 'tls11', 'tls') {
             $tcpClient = New-Object Net.Sockets.TcpClient;
-            $tcpClient.Connect($uri.Host, $uri.Port)
+            $tcpClient.Connect($testEndpoint.Host, $testEndpoint.Port)
     
             $sslStream = New-Object Net.Security.SslStream $tcpClient.GetStream();
             $sslStream.ReadTimeout = 15000;
             $sslStream.WriteTimeout = 15000;
 
             try {
-                $sslStream.AuthenticateAsClient($uri.Host, $null, $protocol, $false);
+                $sslStream.AuthenticateAsClient($testEndpoint.Host, $null, $protocol, $false);
                 $supports = $true;
             }
             catch {
@@ -68,9 +89,11 @@ Function Invoke-WebFileRequest {
     }
 
     # Download the file
-    (New-Object System.Net.WebClient).DownloadFile($url, $destinationPath);
+    $tcpClient = New-Object System.Net.WebClient;
+    $tcpClient.Proxy = $proxy;
+    $tcpClient.DownloadFile($url, $destinationPath);
 
-    if ($secure) {
+    if ($secure -and $oldSecurityProtocol) {
         # Restore the security protocol
         [System.Net.ServicePointManager]::SecurityProtocol = $oldSecurityProtocol;
     }


### PR DESCRIPTION
Use a proxy server if one is defined. First check if there is a system level proxy. If there is not look at `HTTP_PROXY` and `HTTPS_PROXY` environment variables and create a `WebProxy` from those values. Finally negotiate the SSL security provider based on a proxy endpoint or the file's endpoint.