### PR TITLE
Use gnuwin32 version of gperf and diff due to line ending issues

### DIFF
--- a/WebKitDev/Functions/Install-DiffUtils.ps1
+++ b/WebKitDev/Functions/Install-DiffUtils.ps1
@@ -7,8 +7,41 @@
   Installs diff utils.
 
   .Description
-  Installs the latest version of diff utils provided by MSYS2.
+  Downloads the specified release of diff utils and unzips it to the specified
+  location on disk.
+
+  Before installation `Register-SystemPath` should be used to add the install
+  location to the system path.
+
+  .Link Register-SystemPath
+
+  .Parameter Version
+  The version of diff utils to install.
+
+  .Parameter InstallationPath
+  The path to install at.
+
+  .Example
+    # Install 2.8.7.1
+    Install-DiffUtils -Version 2.8.7.1 -InstallationPath C:\gnuwin32
 #>
 Function Install-DiffUtils {
-    Install-FromPacman -Name 'diffutils' -VerifyExe 'diff3'
+    Param(
+        [Parameter(Mandatory)]
+        [string] $version,
+        [Parameter(Mandatory)]
+        [string] $installationPath
+    )
+
+    # There is a commandlet `diff` so use `diff3` as a check for success
+
+    $major, $minor, $patch, $build = $version.split('.');
+
+    $url = ('https://newcontinuum.dl.sourceforge.net/project/gnuwin32/diffutils/{0}.{1}.{2}-{3}/diffutils-{0}.{1}.{2}-{3}-bin.zip' -f $major, $minor, $patch, $build);
+
+    Install-FromArchive -Name 'diff3' -Url $url -InstallationPath $installationPath -NoVerify;
+
+    $depsUrl = ('https://newcontinuum.dl.sourceforge.net/project/gnuwin32/diffutils/{0}.{1}.{2}-{3}/diffutils-{0}.{1}.{2}-{3}-dep.zip' -f $major, $minor, $patch, $build);
+
+    Install-FromArchive -Name 'diff3' -Url $depsUrl -InstallationPath $installationPath  
 }

--- a/WebKitDev/Functions/Install-Gperf.ps1
+++ b/WebKitDev/Functions/Install-Gperf.ps1
@@ -7,8 +7,33 @@
   Installs gperf.
 
   .Description
-  Installs the latest version of gperf provided by MSYS2.
+  Downloads the specified release of gperf and unzips it to the specified
+  location on disk.
+
+  Before installation `Register-SystemPath` should be used to add the install
+  location to the system path.
+
+  .Link Register-SystemPath
+
+  .Parameter Version
+  The version of gperf to install.
+
+  .Parameter InstallationPath
+  The path to install at.
+
+  .Example
+    # Install 3.0.1
+    Install-Gperf -Version 3.0.1 -InstallationPath C:\gnuwin32
 #>
 Function Install-Gperf {
-    Install-FromPacman -Name 'gperf'
+    Param(
+        [Parameter(Mandatory)]
+        [string] $version,
+        [Parameter(Mandatory)]
+        [string] $installationPath
+    )
+
+    $url = ('https://newcontinuum.dl.sourceforge.net/project/gnuwin32/gperf/{0}/gperf-{0}-bin.zip' -f $version);
+
+    Install-FromArchive -Name 'gperf' -Url $url -InstallationPath $installationPath;
 }


### PR DESCRIPTION
Due to these tools apparently causing issues with line endings, move back to the gnuwin32 version rather than msys version.