### PR TITLE
[wip] Add -X utf8 to command for python

### DIFF
--- a/WebKitDev/Functions/Update-XamppPythonLocation.ps1
+++ b/WebKitDev/Functions/Update-XamppPythonLocation.ps1
@@ -29,7 +29,7 @@ Function Update-XamppPythonLocation {
         return;
     }
 
-    $registryValue = ('{0}' -f $pythonExecutable);
+    $registryValue = ('{0} -X utf8' -f $pythonExecutable);
 
     # Add python filetype value
     $registryPath = 'HKCR:\.py\Shell\ExecCGI\Command';


### PR DESCRIPTION
Per Fujii-san's comment on https://bugs.webkit.org/show_bug.cgi?id=223496
this should fix some test failures due to codec conversion failures.

Waiting to see what happens after manually updating in instances.