### PR TITLE
fix(): Use GitHub for CMake 3.20+ downloads

### DIFF
--- a/WebKitDev/Functions/Install-CMake.ps1
+++ b/WebKitDev/Functions/Install-CMake.ps1
@@ -30,7 +30,12 @@ Function Install-CMake {
 
     $major, $minor, $patch = $version.split('.');
 
-    $url = ('https://cmake.org/files/v{0}.{1}/cmake-{2}-win64-x64.msi' -f $major, $minor, $version);
+    # CMake releases moved to GitHub in 3.20
+    if (([int]$major -ge 4) -or (([int]$major -eq 3) -and ([int]$minor -ge 20))) {
+        $url = ('https://github.com/Kitware/CMake/releases/download/v{0}/cmake-{0}-windows-x86_64.msi' -f $version)
+    } else {
+        $url = ('https://cmake.org/files/v{0}.{1}/cmake-{2}-win64_x64.msi' -f $major, $minor, $version);
+    }
 
     $options = @(
         'ADD_CMAKE_TO_PATH="System"'


### PR DESCRIPTION
Since CMake 3.20 the releases of CMake moved to GitHub. The MSI installer name also changed.