### PR TITLE
Remove VC for Python 2.7 download

### DIFF
--- a/WebKitDev/Functions/Install-Python.ps1
+++ b/WebKitDev/Functions/Install-Python.ps1
@@ -77,11 +77,4 @@ Function Install-Python {
 
     python get-pip.py $pipInstall;
     Remove-Item get-pip.py -Force;
-
-    if ($major -eq '2') {
-        # Install Visual Studio for Python 2.7
-        $vcForPythonUrl = 'https://download.microsoft.com/download/7/9/6/796EF2E4-801B-4FC4-AB28-B59FBF6D907B/VCForPython27.msi';
-
-        Install-FromMsi -Name 'VCForPython27' -Url $vcForPythonUrl -NoVerify;
-    }
 }


### PR DESCRIPTION
VCForPython27 is no longer available. It appears the necessary python
packages for testwebkitpy do install without it per build at
https://build.webkit.org/#/builders/60/builds/1099/steps/12/logs/stdio