### PR TITLE
fix(): Fix linter warnings

### DIFF
--- a/Invoke-Linter.ps1
+++ b/Invoke-Linter.ps1
@@ -51,11 +51,9 @@ foreach ($script in $psScripts) {
     $files++;
     $scriptPath = $script.FullName;
 
-    $records = Invoke-ScriptAnalyzer -Path $scriptPath `
-         -Exclude PSUseSingularNouns,PSAvoidUsingInvokeExpression,PSUseShouldProcessForStateChangingFunctions `
-
     Write-Information -MessageData ('Analyzing {0}' -f $scriptPath) -InformationAction Continue;
 
+    $records = Invoke-ScriptAnalyzer -Path $scriptPath -Settings (Join-Path $PSScriptRoot 'ScriptAnalyzerSettings.txt');
     if ($records) {
         foreach ($record in $records) {
             $issues++;

--- a/ScriptAnalyzerSettings.txt
+++ b/ScriptAnalyzerSettings.txt
@@ -1,0 +1,10 @@
+@{
+    Severity = @('Error','Warning','Information')
+    IncludeRules = '*'
+    ExcludeRules = @(
+        'PSUseSingularNouns',
+        'PSAvoidUsingInvokeExpression',
+        'PSUseShouldProcessForStateChangingFunctions',
+        'PSReviewUnusedParameter'
+    )
+}

--- a/WebKitDev/Functions/Get-SourceCodeRelease.ps1
+++ b/WebKitDev/Functions/Get-SourceCodeRelease.ps1
@@ -25,17 +25,17 @@ function Get-SourceCodeRelease {
         [string]$destinationPath
     )
 
-    Write-Host ('Downloading {0} source code from {1} ...' -f $name,$url);
+    Write-Information -MessageData ('Downloading {0} source code from {1} ...' -f $name,$url) -InformationAction Continue;
     $extension = [System.IO.Path]::GetExtension($url);
     $fileName = [System.IO.Path]::GetTempFileName() | Rename-Item -NewName { $_ -replace '.tmp$',$extension } -Passthru;
     Invoke-WebFileRequest -url $url -DestinationPath $fileName;
-    Write-Host ('Downloaded {0} bytes' -f (Get-Item $fileName).Length);
+    Write-Information -MessageData ('Downloaded {0} bytes' -f (Get-Item $fileName).Length) -InformationAction Continue;
 
-    Write-Host ('Unzipping {0} source code to {1} ...' -f $name,$destinationPath);
+    Write-Information -MessageData ('Unzipping {0} source code to {1} ...' -f $name,$destinationPath) -InformationAction Continue;
     Expand-SourceArchive -Path $fileName -DestinationPath $destinationPath;
 
     # Clean up temporary files
     Remove-Item $fileName -Force;
 
-    Write-Host 'Complete';
+    Write-Information -MessageData 'Complete' -InformationAction Continue;
 }

--- a/WebKitDev/Functions/Install-AhemFont.ps1
+++ b/WebKitDev/Functions/Install-AhemFont.ps1
@@ -9,7 +9,7 @@
   .Description
   Downloads the AHEM font and installs it into the system fonts.
 
-  The AHEM font is used for layout tests in WebKit and is retrieved from 
+  The AHEM font is used for layout tests in WebKit and is retrieved from
   https://github.com/w3c/web-platform-tests.
 #>
 function Install-AhemFont {

--- a/WebKitDev/Functions/Install-Font.ps1
+++ b/WebKitDev/Functions/Install-Font.ps1
@@ -18,9 +18,9 @@ function Install-Font {
     $filename = [System.IO.Path]::GetFilename($url);
     $fontPath = Join-Path ([System.IO.Path]::GetTempPath()) $filename;
 
-    Write-Host ('Downloading {0} font from {1} ..' -f $name,$url);
+    Write-Information -MessageData ('Downloading {0} font from {1} ..' -f $name,$url) -InformationAction Continue;
     Invoke-WebFileRequest -url $url -DestinationPath $fontPath;
-    Write-Host ('Downloaded {0} bytes' -f (Get-Item $fontPath).Length);
+    Write-Information -MessageData ('Downloaded {0} bytes' -f (Get-Item $fontPath).Length) -InformationAction Continue;
 
     # Retrieve the font's name
     if (-not ('System.Drawing.Text.PrivateFontCollection' -as [type])) {
@@ -31,14 +31,14 @@ function Install-Font {
     $fontCollection.AddFontFile($fontPath);
     $fontName = $fontCollection.Families.Name;
 
-    Write-Host ('Installing font {0} from {1}' -f $fontName,$filename);
+    Write-Information -MessageData ('Installing font {0} from {1}' -f $fontName,$filename) -InformationAction Continue;
 
     # Move the file to the correct location
     $shell = New-Object -ComObject Shell.Application;
     $fonts = $shell.Namespace(0x14);
     $installationPath = $fonts.Self.Path;
 
-    Write-Host ('Installing at {0}' -f $installationPath);
+    Write-Information -MessageData ('Installing at {0}' -f $installationPath) -InformationAction Continue;
 
     $fonts.CopyHere($fontPath);
 
@@ -57,12 +57,12 @@ function Install-Font {
     $registryTest = Get-ItemProperty -Path $registryPath -Name $registryKey -ErrorAction SilentlyContinue;
 
     if (-not ($registryTest)) {
-        Write-Host ('Writing {0} : {1} at ${2}' -f $registryKey,$filename,$registryPath);
+        Write-Information -MessageData ('Writing {0} : {1} at ${2}' -f $registryKey,$filename,$registryPath) -InformationAction Continue;
         New-ItemProperty -Path $registryPath -Name $registryKey -PropertyType String -Value $filename | Out-Null;
     }
     else {
-        Write-Host 'Font already present in registry';
-        Write-Host ('Value {0} : {1} at ${2}' -f $registryKey,$registryTest.$registryKey,$registryPath);
+        Write-Information -MessageData 'Font already present in registry' -InformationAction Continue;
+        Write-Information -MessageData ('Value {0} : {1} at ${2}' -f $registryKey,$registryTest.$registryKey,$registryPath) -InformationAction Continue;
     }
 
     # Verify that the font is present

--- a/WebKitDev/Functions/Install-FromArchive.ps1
+++ b/WebKitDev/Functions/Install-FromArchive.ps1
@@ -43,10 +43,10 @@ function Install-FromArchive {
     $extension = [System.IO.Path]::GetExtension($url);
     $archivePath = Join-Path ([System.IO.Path]::GetTempPath()) ('{0}.{1}' -f $name,$extension);
 
-    Write-Host ('Downloading {0} package from {1} ..' -f $name,$url);
+    Write-Information -MessageData ('Downloading {0} package from {1} ..' -f $name,$url) -InformationAction Continue;
     Invoke-WebFileRequest -url $url -DestinationPath $archivePath;
-    Write-Host ('Downloaded {0} bytes' -f (Get-Item $archivePath).Length);
-    Write-Host ('Unzipping {0} package ...' -f $name);
+    Write-Information -MessageData ('Downloaded {0} bytes' -f (Get-Item $archivePath).Length) -InformationAction Continue;
+    Write-Information -MessageData ('Unzipping {0} package ...' -f $name) -InformationAction Continue;
 
     # Determine where to expand the archive to
     #
@@ -68,16 +68,16 @@ function Install-FromArchive {
     }
 
     if (!$noVerify) {
-        Write-Host ('Verifying {0} install ...' -f $name);
+        Write-Information -MessageData ('Verifying {0} install ...' -f $name) -InformationAction Continue;
         $verifyCommand = ('  {0} --version' -f $name);
-        Write-Host $verifyCommand;
+        Write-Information -MessageData $verifyCommand -InformationAction Continue;
         Invoke-Expression $verifyCommand;
     }
 
-    Write-Host ('Removing {0} package  ...' -f $name);
+    Write-Information -MessageData ('Removing {0} package  ...' -f $name) -InformationAction Continue;
     Remove-Item $archivePath -Force;
 
-    Write-Host ('{0} install complete.' -f $name);
+    Write-Information -MessageData ('{0} install complete.' -f $name) -InformationAction Continue;
 }
 
 function Move-DirectoryStructure {

--- a/WebKitDev/Functions/Install-FromExe.ps1
+++ b/WebKitDev/Functions/Install-FromExe.ps1
@@ -39,12 +39,12 @@ function Install-FromExe {
 
     $installerPath = Join-Path ([System.IO.Path]::GetTempPath()) ('{0}.exe' -f $name);
 
-    Write-Host ('Downloading {0} installer from {1} ..' -f $name,$url);
+    Write-Information -MessageData ('Downloading {0} installer from {1} ..' -f $name,$url) -InformationAction Continue;
     Invoke-WebFileRequest -url $url -DestinationPath $installerPath;
-    Write-Host ('Downloaded {0} bytes' -f (Get-Item $installerPath).Length);
+    Write-Information -MessageData ('Downloaded {0} bytes' -f (Get-Item $installerPath).Length) -InformationAction Continue;
 
-    Write-Host ('Installing {0} ...' -f $name);
-    Write-Host ('{0} {1}' -f $installerPath,($options -join ' '));
+    Write-Information -MessageData ('Installing {0} ...' -f $name) -InformationAction Continue;
+    Write-Information -MessageData ('{0} {1}' -f $installerPath,($options -join ' ')) -InformationAction Continue;
 
     Start-Process $installerPath -Wait -ArgumentList $options;
 
@@ -52,15 +52,15 @@ function Install-FromExe {
     Update-ScriptPath;
 
     if (!$noVerify) {
-        Write-Host ('Verifying {0} install ...' -f $name);
+        Write-Information -MessageData ('Verifying {0} install ...' -f $name) -InformationAction Continue;
         $verifyCommand = ('  {0} --version' -f $name);
-        Write-Host $verifyCommand;
+        Write-Information -MessageData $verifyCommand -InformationAction Continue;
         Invoke-Expression $verifyCommand;
     }
 
-    Write-Host ('Removing {0} installer ...' -f $name);
+    Write-Information -MessageData ('Removing {0} installer ...' -f $name) -InformationAction Continue;
     Remove-Item $installerPath -Force;
     Remove-TempFiles;
 
-    Write-Host ('{0} install complete.' -f $name);
+    Write-Information -MessageData ('{0} install complete.' -f $name) -InformationAction Continue;
 }

--- a/WebKitDev/Functions/Install-FromExeDownload.ps1
+++ b/WebKitDev/Functions/Install-FromExeDownload.ps1
@@ -45,19 +45,19 @@ function Install-FromExeDownload {
     }
 
     $exePath = Join-Path $installationPath ('{0}.exe' -f $name);
-    Write-Host ('Downloading {0} executable from {1} ...' -f $name,$url);
+    Write-Information -MessageData ('Downloading {0} executable from {1} ...' -f $name,$url) -InformationAction Continue;
     Invoke-WebFileRequest -url $url -DestinationPath $exePath;
-    Write-Host ('Downloaded {0} bytes' -f (Get-Item $exePath).Length);
+    Write-Information -MessageData ('Downloaded {0} bytes' -f (Get-Item $exePath).Length) -InformationAction Continue;
 
     # Update path
     Update-ScriptPath;
 
     if (!$noVerify) {
-        Write-Host ('Verifying {0} install ...' -f $name);
+        Write-Information -MessageData ('Verifying {0} install ...' -f $name) -InformationAction Continue;
         $verifyCommand = ('  {0} {1}' -f $name,(' ' -join $versionOptions));
-        Write-Host $verifyCommand;
+        Write-Information -MessageData $verifyCommand -InformationAction Continue;
         Invoke-Expression $verifyCommand;
     }
 
-    Write-Host ('{0} install complete.' -f $name);
+    Write-Information -MessageData ('{0} install complete.' -f $name) -InformationAction Continue;
 }

--- a/WebKitDev/Functions/Install-FromMsi.ps1
+++ b/WebKitDev/Functions/Install-FromMsi.ps1
@@ -39,31 +39,31 @@ function Install-FromMsi {
 
     $installerPath = Join-Path ([System.IO.Path]::GetTempPath()) ('{0}.msi' -f $name);
 
-    Write-Host ('Downloading {0} installer from {1} ..' -f $name,$url);
+    Write-Information -MessageData ('Downloading {0} installer from {1} ..' -f $name,$url) -InformationAction Continue;
     Invoke-WebFileRequest -url $url -DestinationPath $installerPath;
-    Write-Host ('Downloaded {0} bytes' -f (Get-Item $installerPath).Length);
+    Write-Information -MessageData ('Downloaded {0} bytes' -f (Get-Item $installerPath).Length) -InformationAction Continue;
 
-    $args = @('/i',$installerPath,'/quiet','/qn');
-    $args += $options;
+    $msiArgs = @('/i',$installerPath,'/quiet','/qn');
+    $msiArgs += $options;
 
-    Write-Host ('Installing {0} ...' -f $name);
-    Write-Host ('msiexec {0}' -f ($args -join ' '));
+    Write-Information -MessageData ('Installing {0} ...' -f $name) -InformationAction Continue;
+    Write-Information -MessageData ('msiexec {0}' -f ($msiArgs -join ' ')) -InformationAction Continue;
 
-    Start-Process msiexec -Wait -ArgumentList $args;
+    Start-Process msiexec -Wait -ArgumentList $msiArgs;
 
     # Update path
     Update-ScriptPath;
 
     if (!$noVerify) {
-        Write-Host ('Verifying {0} install ...' -f $name);
+        Write-Information -MessageData ('Verifying {0} install ...' -f $name) -InformationAction Continue;
         $verifyCommand = ('  {0} --version' -f $name);
-        Write-Host $verifyCommand;
+        Write-Information -MessageData $verifyCommand -InformationAction Continue;
         Invoke-Expression $verifyCommand;
     }
 
-    Write-Host ('Removing {0} installer ...' -f $name);
+    Write-Information -MessageData ('Removing {0} installer ...' -f $name) -InformationAction Continue;
     Remove-Item $installerPath -Force;
     Remove-TempFiles;
 
-    Write-Host ('{0} install complete.' -f $name);
+    Write-Information -MessageData ('{0} install complete.' -f $name) -InformationAction Continue;
 }

--- a/WebKitDev/Functions/Install-FromPacman.ps1
+++ b/WebKitDev/Functions/Install-FromPacman.ps1
@@ -29,7 +29,7 @@ function Install-FromPacman {
         [switch]$noVerify = $false
     )
     $bash = Get-Command 'bash' -ErrorAction 'SilentlyContinue';
-    if ($bash -eq $null) {
+    if ($null -eq $bash) {
         Write-Error ('Could not find bash to use to install {0}' -f $name);
         return
     }
@@ -42,7 +42,7 @@ function Install-FromPacman {
 
     $bashCmd = ('pacman --noconfirm -S {0}' -f $name);
     $bashExpression = ("bash -lc '{0}'" -f $bashCmd);
-    Write-Host $bashCmd;
+    Write-Information -MessageData $bashCmd -InformationAction Continue;
     Invoke-Expression $bashExpression > $outFile;
     Get-Content $outFile;
 
@@ -50,9 +50,9 @@ function Install-FromPacman {
         if ($verifyExe -eq '') {
             $verifyExe = $name;
         }
-        Write-Host ('Verifying {0} install ...' -f $name);
+        Write-Information -MessageData ('Verifying {0} install ...' -f $name) -InformationAction Continue;
         $verifyCommand = ('  {0} --version' -f $verifyExe);
-        Write-Host $verifyCommand;
+        Write-Information -MessageData $verifyCommand -InformationAction Continue;
         Invoke-Expression $verifyCommand > $outFile;
         Get-Content $outFile;
     }

--- a/WebKitDev/Functions/Install-MSYS2.ps1
+++ b/WebKitDev/Functions/Install-MSYS2.ps1
@@ -37,7 +37,7 @@ function Install-MSYS2 {
     # Setup the environment
     #
     # This is taken from different dockerfiles that do not call `msys2_shell.cmd`.
-    Write-Host 'Initializing MSYS2 environment';
+    Write-Information -MessageData 'Initializing MSYS2 environment' -InformationAction Continue;
     $env:MSYSTEM = 'MSYS2';
     $env:MSYSCON = 'defterm';
     [Environment]::SetEnvironmentVariable('MSYSTEM',$env:MSYSTEM,[EnvironmentVariableTarget]::Machine);
@@ -50,17 +50,17 @@ function Install-MSYS2 {
     $outFile = New-TemporaryFile;
 
     # Run bash a singular time
-    Write-Host "`n=================  STARTING BASH  =================`n"
+    Write-Information -MessageData '`n=================  STARTING BASH  =================`n' -InformationAction Continue;
     Set-Alias bash (Join-Path $installationPath -ChildPath 'usr' | Join-Path -ChildPath 'bin' | Join-Path -ChildPath 'bash.exe');
     bash.exe -lc 'exit 0' > $outFile;
     Get-Content $outFile;
 
     # Update steps taken from chocolatey package
     # https://github.com/msys2/msys2/wiki/MSYS2-installation
-    Write-Host 'Repeating system update until there are no more updates or max 5 iterations';
+    Write-Information -MessageData 'Repeating system update until there are no more updates or max 5 iterations' -InformationAction Continue;
     $ErrorActionPreference = 'Continue'; # otherwise bash warnings will exit
     while (!$done) {
-        Write-Host "`n================= SYSTEM UPDATE $((++$i)) =================`n";
+        Write-Information -MessageData '`n================= SYSTEM UPDATE $((++$i)) =================`n' -InformationAction Continue;
         bash.exe -lc 'pacman --noconfirm -Syuu' > $outFile;
         Get-Content $outFile;
         $done = (Get-Content $outFile) -match 'there is nothing to do' | Measure-Object | ForEach-Object { $_.Count -eq 2 };

--- a/WebKitDev/Functions/Install-Python.ps1
+++ b/WebKitDev/Functions/Install-Python.ps1
@@ -71,7 +71,7 @@ function Install-Python {
 
     # Install PIP
     $pipInstall = ('pip=={0}' -f $pipVersion);
-    Write-Host ('Installing {0} from {1} ...' -f ($pipInstall,$getPip));
+    Write-Information -MessageData ('Installing {0} from {1} ...' -f ($pipInstall,$getPip)) -InformationAction Continue;
 
     Invoke-WebFileRequest -url $getPip -DestinationPath 'get-pip.py';
 

--- a/WebKitDev/Functions/Invoke-CMakeBuild.ps1
+++ b/WebKitDev/Functions/Invoke-CMakeBuild.ps1
@@ -37,7 +37,7 @@ function Invoke-CMakeBuild {
         [string]$installationPath,
         [Parameter(Mandatory)]
         [ValidateSet('Release','Debug','RelWithDebInfo','MinSizeRel')]
-        [string]$buildType = 'Release',
+        [string]$buildType,
         [ValidateSet('ninja','vs2015','vs2017')]
         [string]$generator = 'ninja',
         [Parameter()]
@@ -77,7 +77,7 @@ function Invoke-CMakeBuild {
     # Create the generate call
     $genCall = ('cmake {0}' -f ($genArgs -join ' '));
 
-    Write-Host $genCall;
+    Write-Information -MessageData $genCall -InformationAction Continue;
     Invoke-Expression $genCall
 
     # Create the build call
@@ -89,7 +89,7 @@ function Invoke-CMakeBuild {
 
     $buildCall = ('cmake {0}' -f ($buildArgs -join ' '));
 
-    Write-Host $buildCall;
+    Write-Information -MessageData $buildCall -InformationAction Continue;
     Invoke-Expression $buildCall;
     $cmakeExitCode = $LASTEXITCODE;
 

--- a/WebKitDev/Functions/Invoke-WebFileRequest.ps1
+++ b/WebKitDev/Functions/Invoke-WebFileRequest.ps1
@@ -31,9 +31,8 @@ function Invoke-WebFileRequest {
 
     # Setup a proxy if needed
     $proxy = [System.Net.WebProxy]::GetDefaultProxy();
-    $proxyServer = $proxy.Address;
 
-    if ($proxy.Address -eq $null) {
+    if ($null -ne $proxy.Address) {
         if ($secure) {
             if (Test-Path env:HTTPS_PROXY) {
                 $proxy = New-Object System.Net.WebProxy ($env:HTTPS_PROXY,$true);
@@ -59,7 +58,7 @@ function Invoke-WebFileRequest {
         $securityProtocol = 0;
         $testEndpoint = [System.Uri]$url;
 
-        if ($proxy.Address -ne $null) {
+        if ($null -ne $proxy.Address) {
             $testEndpoint = $proxy.Address;
         }
 

--- a/WebKitDev/Functions/Register-SystemPath.ps1
+++ b/WebKitDev/Functions/Register-SystemPath.ps1
@@ -30,7 +30,7 @@ function Register-SystemPath {
         return;
     }
 
-    Write-Host ('Adding {0} to the system path' -f $path);
+    Write-Information -MessageData ('Adding {0} to the system path' -f $path) -InformationAction Continue;
 
     # Get current path from the registry
     $systemPathKey = 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment';

--- a/WebKitDev/Functions/Remove-TempFiles.ps1
+++ b/WebKitDev/Functions/Remove-TempFiles.ps1
@@ -12,7 +12,7 @@
 function Remove-TempFiles {
     $tempFolders = @($env:temp,'C:/Windows/temp')
 
-    Write-Host 'Removing temporary files';
+    Write-Information -MessageData 'Removing temporary files' -InformationAction Continue;
     $attempts = 1;
     $maxAttempts = 5;
     $filesRemoved = 0;
@@ -38,24 +38,24 @@ function Remove-TempFiles {
 
         # Break out of the loop if there were no problems
         if ($couldNotRemove.Count -eq 0) {
-            Write-Host ('All files have been removed');
+            Write-Information -MessageData ('All files have been removed') -InformationAction Continue;
             break;
         }
 
-        Write-Host ('Could not remove {0} files from temporary directories' -f $couldNotRemove.Count)
+        Write-Information -MessageData ('Could not remove {0} files from temporary directories' -f $couldNotRemove.Count) -InformationAction Continue;
 
         # Break out of the loop after all attempts are exhausted
         if ($attempts -eq $maxAttempts) {
             break;
         }
 
-        Write-Host ('Waiting {0} seconds till next attempt' -f $sleepFor);
+        Write-Information -MessageData ('Waiting {0} seconds till next attempt' -f $sleepFor) -InformationAction Continue;
         Start-Sleep -Seconds $sleepFor;
 
         $attempts += 1;
         $sleepFor *= $sleepMultiplier;
-        Write-Host ('Attempt {0} of {1}' -f $attempts,$maxAttempts);
+        Write-Information -MessageData ('Attempt {0} of {1}' -f $attempts,$maxAttempts) -InformationAction Continue;
     }
 
-    Write-Host ('Removed {0} files from temporary directories' -f $filesRemoved)
+    Write-Information -MessageData ('Removed {0} files from temporary directories' -f $filesRemoved) -InformationAction Continue;
 }

--- a/WebKitDev/Functions/Select-VSEnvironment.ps1
+++ b/WebKitDev/Functions/Select-VSEnvironment.ps1
@@ -29,19 +29,19 @@ function Select-VSEnvironment {
     # Find version if not specified
     if (!$version) {
         if (Test-Path (Get-VSBuildTools2022InstallationPath)) {
-            Write-Host 'Found VS2022 Build Tools';
+            Write-Information -MessageData 'Found VS2022 Build Tools' -InformationAction Continue;
             $version = 'vs2022';
         }
         elseif (Test-Path (Get-VSBuildTools2019InstallationPath)) {
-            Write-Host 'Found VS2019 Build Tools';
+            Write-Information -MessageData 'Found VS2019 Build Tools' -InformationAction Continue;
             $version = 'vs2019';
         }
         elseif (Test-Path (Get-VSBuildTools2017InstallationPath)) {
-            Write-Host 'Found VS2017 Build Tools';
+            Write-Information -MessageData 'Found VS2017 Build Tools' -InformationAction Continue;
             $version = 'vs2017';
         }
         elseif (Test-Path (Get-VSBuildTools2015InstallationPath)) {
-            Write-Host 'Found VS2015 Build Tools';
+            Write-Information -MessageData 'Found VS2015 Build Tools' -InformationAction Continue;
             $version = 'vs2015';
         }
         else {
@@ -66,7 +66,7 @@ function Select-VSEnvironment {
         $vcvars = Get-VSBuildTools2015VCVarsAllPath;
     }
 
-    Write-Host $vcvars;
+    Write-Information -MessageData $vcvars -InformationAction Continue;
 
     if (!(Test-Path $vcvars)) {
         Write-Error ('Could not find {0}' -f $vcvars);
@@ -79,7 +79,7 @@ function Select-VSEnvironment {
     $compilerExe = 'cl.exe';
     $compilerPath = (Get-Command $compilerExe).Path;
 
-    Write-Host ('Found compiler at {0}' -f $compilerPath);
+    Write-Information -MessageData ('Found compiler at {0}' -f $compilerPath) -InformationAction Continue;
 
     Initialize-NinjaEnvironment -Cc $compilerPath -cxx $compilerPath;
 }

--- a/WebKitDev/Functions/Update-XamppPerlLocation.ps1
+++ b/WebKitDev/Functions/Update-XamppPerlLocation.ps1
@@ -41,7 +41,7 @@ function Update-XamppPerlLocation {
         New-Item -Path $registryPath -Force | Out-Null;
     }
 
-    Write-Host ('Writing {0} : {1} at {2}' -f $registryKey,$registryValue,$registryPath);
+    Write-Information -MessageData ('Writing {0} : {1} at {2}' -f $registryKey,$registryValue,$registryPath) -InformationAction Continue;
     New-ItemProperty -Path $registryPath -Name $registryKey -PropertyType String -Value $registryValue -Force | Out-Null;
 
     # Add CGI filetype value
@@ -52,6 +52,6 @@ function Update-XamppPerlLocation {
         New-Item -Path $registryPath -Force | Out-Null;
     }
 
-    Write-Host ('Writing {0} : {1} at {2}' -f $registryKey,$registryValue,$registryPath);
+    Write-Information -MessageData ('Writing {0} : {1} at {2}' -f $registryKey,$registryValue,$registryPath) -InformationAction Continue;
     New-ItemProperty -Path $registryPath -Name $registryKey -PropertyType String -Value $registryValue -Force | Out-Null;
 }

--- a/WebKitDev/Functions/Update-XamppPythonLocation.ps1
+++ b/WebKitDev/Functions/Update-XamppPythonLocation.ps1
@@ -39,6 +39,6 @@ function Update-XamppPythonLocation {
         New-Item -Path $registryPath -Force | Out-Null;
     }
 
-    Write-Host ('Writing {0} : {1} at {2}' -f $registryKey,$registryValue,$registryPath);
+    Write-Information -MessageData ('Writing {0} : {1} at {2}' -f $registryKey,$registryValue,$registryPath) -InformationAction Continue;
     New-ItemProperty -Path $registryPath -Name $registryKey -PropertyType String -Value $registryValue -Force | Out-Null;
 }


### PR DESCRIPTION
Fix all the PSAvoidUsingWriteHost issues by using `Write-Information` instead.

Fix PSAvoidAssignmentToAutomaticVariable in `Install-FromMsi.ps1` by renaming a variable.

Fix a PSAvoidTrailingWhitespace lint in the documentation for `Install-AhemFont.ps1`.

Fix a PSAvoidDefaultValueForMandatoryParameter lint in `Invoke-CmakeBuild.ps1`.

Fix a PSUseDeclaredVarsMoreThanAssignments lint in `Invoke-WebFileRequest.ps1`.