### PR TITLE
ci(): Publish release on tag

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -29,6 +29,19 @@ steps:
     # Disable debugging and profiling
     COMPlus_EnableDiagnostics: 0
 
+- name: publish
+  image: mcr.microsoft.com/dotnet/sdk:6.0-alpine
+  commands:
+  - pwsh ./Publish-WebKitDev.ps1
+  environment:
+    NUGET_API_KEY:
+      from_secret: nuget_api_key
+    # Disable debugging and profiling
+    COMPlus_EnableDiagnostics: 0
+  when:
+    event:
+    - tag
+
 trigger:
   ref:
   - refs/heads/master

--- a/Publish-WebKitDev.ps1
+++ b/Publish-WebKitDev.ps1
@@ -1,0 +1,29 @@
+param(
+    [string]$nugetApiKey
+)
+
+$ErrorActionPreference = 'Stop';
+
+if (-not ($nugetApiKey)) {
+    $nugetApiKey = $Env:NUGET_API_KEY;
+
+    if (-not ($nugetApiKey)) {
+        Write-Error 'API key is not specified on command line or in Env:NUGET_API_KEY';
+    }
+}
+
+Set-PSRepository -Name PSGallery -InstallationPolicy Trusted;
+
+# Need to install the modules otherwise the tests will fail
+if (-not (Get-Module -Name '7Zip4Powershell')) {
+    Write-Information -MessageData 'Installing 7Zip4Powershell dependency' -InformationAction Continue;
+    Install-Module -Name '7Zip4Powershell' -RequiredVersion 1.13.0 -Force;
+}
+
+if (-not (Get-Module -Name 'VSSetup')) {
+    Write-Information -MessageData 'Installing VSSetup dependency' -InformationAction Continue;
+    Install-Module -Name 'VSSetup' -RequiredVersion 2.2.16 -Force;
+}
+
+Write-Information -MessageData 'Publishing WebKitDev package' -InformationAction Continue;
+Publish-Module -Path (Join-Path $PSScriptRoot WebKitDev) -NuGetApiKey $nugetApiKey -Force;


### PR DESCRIPTION
Execute `Publish-Module` whenever a new tag is pushed. Add a script to setup the CI so it can publish the module.

Before publishing the package it is verified. If the dependencies are not present then it will fail.