### PR TITLE
fix(): Check exit code for installs

### DIFF
--- a/WebKitDev/Functions/Install-FromMsi.ps1
+++ b/WebKitDev/Functions/Install-FromMsi.ps1
@@ -49,7 +49,15 @@ function Install-FromMsi {
     Write-Information -MessageData ('Installing {0} ...' -f $name) -InformationAction Continue;
     Write-Information -MessageData ('msiexec {0}' -f ($msiArgs -join ' ')) -InformationAction Continue;
 
-    Start-Process msiexec -Wait -ArgumentList $msiArgs;
+    # According to https://stackoverflow.com/a/23797762 caching the handle is required to get ExitCode
+    $process = Start-Process msiexec -PassThru -ArgumentList $msiArgs;
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUserDeclaredVarsMoreThanAssignments', '', Scope='Function')]
+    $handle = $process.Handle;
+    $process.WaitForExit();
+
+    if ($process.ExitCode -ne 0) {
+        Write-Error ('{0} installer failed with exit code {1}' -f $name, $process.ExitCode) -ErrorAction Stop;
+    }
 
     # Update path
     Update-ScriptPath;


### PR DESCRIPTION
Modify `Start-Process` code to check for a successful exit code. If the code is non-zero the installation fails.

Fixes an issue where xampp installs were silently failing because there's no executable to verify.